### PR TITLE
Details

### DIFF
--- a/zjb/db.py
+++ b/zjb/db.py
@@ -93,3 +93,10 @@ def get_last_update() -> str:
         last_update = last_update[0]
 
     return last_update
+
+
+def get_result(ID: int) -> dict:
+    with session() as s:
+        result = s.query(Build).filter(Build.id == ID).one_or_none()
+
+    return result

--- a/zjb/db.py
+++ b/zjb/db.py
@@ -76,3 +76,17 @@ class Build(Base):
 
 
 Base.metadata.create_all(engine)
+
+
+def get_last_update() -> str:
+    with session() as s:
+        last_update = (
+            s.query(Build.updated)
+             .order_by(Build.updated.desc())
+             .first()
+        )
+
+    if last_update:
+        last_update = last_update[0]
+
+    return last_update

--- a/zjb/db.py
+++ b/zjb/db.py
@@ -35,6 +35,7 @@ class Build(Base):
     pipeline = Column(String)
     job = Column(String)
     uuid = Column(String)
+    date = Column(DateTime(timezone=True), nullable=True)
     status = Column(String)
     URL = Column(String)
     voting = Column(Boolean)
@@ -43,19 +44,20 @@ class Build(Base):
                      onupdate=func.now())
 
     def __init__(self, project, branch, pipeline, job,
-                 uuid, status, URL, voting):
+                 uuid, date, status, URL, voting):
         self.project = project
         self.branch = branch
         self.pipeline = pipeline
         self.job = job
         self.uuid = uuid
+        self.date = date
         self.status = status
         self.URL = URL
         self.voting = voting
 
     @classmethod
     def create_or_update(cls, session, project, branch, pipeline, job,
-                         uuid, status, URL, voting):
+                         uuid, date, status, URL, voting):
         instance = session.query(cls).filter_by(project=project,
                                                 branch=branch,
                                                 pipeline=pipeline,
@@ -63,12 +65,13 @@ class Build(Base):
 
         if instance:
             instance.uuid = uuid
+            instance.date = date
             instance.status = status
             instance.URL = URL
             instance.voting = voting
         else:
             instance = cls(project, branch, pipeline, job,
-                           uuid, status, URL, voting)
+                           uuid, date, status, URL, voting)
             session.add(instance)
 
         session.commit()

--- a/zjb/puller.py
+++ b/zjb/puller.py
@@ -71,19 +71,22 @@ def update(builds_to_query: list) -> None:
         pipeline, project, branch, job = build_args
 
         build = get_last_build(project, branch, pipeline, job)
-        build_date = datetime.fromisoformat(
-            build.get('start_time', '1970-01-01T00:00:00.000000')
-        )
 
-        if (datetime.now() - build_date).days > config.obsolete_days:
-            build['uuid'] = ''
-            build['result'] = '---'
-            build['log_url'] = ''
-            build['voting'] = True
+        if build.get('uuid') and build.get('start_time'):
+            build['start_time'] = datetime.fromisoformat(
+                build.get('start_time')
+            )
+
+            days_passed = (datetime.now() - build['start_time']).days
+
+            if days_passed > config.obsolete_days:
+                build['result'] = '---'
+                build['voting'] = True
 
         db.Build.create_or_update(
             session, project, branch, pipeline, job,
             build.get('uuid', ''),
+            build.get('start_time'),
             build.get('result', '---'),
             build.get('log_url', ''),
             build.get('voting', True),

--- a/zjb/server.py
+++ b/zjb/server.py
@@ -102,11 +102,8 @@ def get_results(filters: dict) -> dict:
 def index():
     last_update = get_last_update()
 
-    query = request.args.get('q')
-
     return template_index.render(
         last_update=last_update,
-        query=query,
         url_prefix=config.url_prefix,
         views=config.views,
     )

--- a/zjb/server.py
+++ b/zjb/server.py
@@ -18,6 +18,7 @@ app = Flask(__name__)
 
 j2env = Environment(loader=PackageLoader('zjb', 'templates'))
 template_index = j2env.get_template('index.html.j2')
+template_details = j2env.get_template('details.html.j2')
 template_results = j2env.get_template('results.html.j2')
 
 
@@ -99,6 +100,26 @@ def view(name):
         last_update=last_update,
         query=query,
         results=results,
+        url_prefix=config.url_prefix,
+    )
+
+
+@app.route("/details", methods=['GET'])
+def details():
+    ID = request.args.get('id')
+
+    if not ID:
+        abort(400)
+
+    result = db.get_result(ID)
+    last_update = db.get_last_update()
+
+    if not result:
+        abort(404)
+
+    return template_details.render(
+        last_update=last_update,
+        result=result,
         url_prefix=config.url_prefix,
     )
 

--- a/zjb/server.py
+++ b/zjb/server.py
@@ -21,23 +21,6 @@ template_index = j2env.get_template('index.html.j2')
 template_results = j2env.get_template('results.html.j2')
 
 
-def get_last_update() -> str:
-    session = db.session()
-
-    last_update = (
-        session
-        .query(db.Build.updated)
-        .order_by(db.Build.updated.desc())
-        .first()
-    )
-
-    if last_update:
-        last_update = last_update[0]
-
-    session.close()
-    return last_update
-
-
 def get_results(filters: dict) -> dict:
     session = db.session()
     pipelines = [v for (v, ) in session.query(db.Build.pipeline).distinct()]
@@ -100,7 +83,7 @@ def get_results(filters: dict) -> dict:
 
 @app.route("/", methods=['GET'])
 def index():
-    last_update = get_last_update()
+    last_update = db.get_last_update()
 
     return template_index.render(
         last_update=last_update,
@@ -117,7 +100,7 @@ def view(name):
     query = request.args.get('q')
 
     results, headers = get_results(config.views[name])
-    last_update = get_last_update()
+    last_update = db.get_last_update()
 
     return template_results.render(
         name=name,

--- a/zjb/server.py
+++ b/zjb/server.py
@@ -83,7 +83,7 @@ def index():
     )
 
 
-@app.route("/<string:name>", methods=['GET'])
+@app.route("/view/<string:name>", methods=['GET'])
 def view(name):
     if name not in config.views:
         abort(404)

--- a/zjb/server.py
+++ b/zjb/server.py
@@ -63,19 +63,9 @@ def get_results(filters: dict) -> dict:
                     ).one_or_none()
 
                     if build:
-                        results[pipeline][project].append({
-                            'name': job,
-                            'status': build.status,
-                            'URL': build.URL,
-                            'voting': build.voting,
-                        })
+                        results[pipeline][project].append(build.__dict__)
                     else:
-                        results[pipeline][project].append({
-                            'name': '---',
-                            'status': '---',
-                            'URL': '',
-                            'voting': True,
-                        })
+                        results[pipeline][project].append(None)
 
     session.close()
     return results, headers

--- a/zjb/templates/base.html.j2
+++ b/zjb/templates/base.html.j2
@@ -224,6 +224,78 @@
                 text-align: center;
             }
 
+            div.details {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                text-align: left;
+            }
+            div.details strong {
+                border-bottom: 1px solid black;
+                display: block;
+                margin: 0 auto;
+                text-align: center;
+            }
+            div.details table {
+                border: none;
+                margin: 0;
+            }
+            div.details table td {
+                text-align: left !important;
+                max-width: 15em !important;
+                min-width: auto !important;
+                width: 6em !important;
+            }
+            div.details table td:nth-child(2) {
+                width: 20em !important;
+            }
+            div.details table td:nth-child(4) {
+                width: 15em !important;
+            }
+            div.details table td.log {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            div.details table tbody td b.status {
+                border-width: 2px;
+                border-style: solid;
+                border-radius: 0.25em;
+                display: inline-block;
+                font-weight: bold;
+                min-width: 4.0em;
+                padding: 0 0.5em;
+                text-align: center;
+
+                background-color: rgba(146, 131, 116, 0.5);
+                border-color: #928374;
+                color: #7c6f64;
+            }
+            div.details table tbody td b.SUCCESS {
+                background-color: rgba(152, 151, 26, 0.5);
+                border-color: #98971a;
+                color: #79740e;
+            }
+            div.details table tbody td b.FAILURE {
+                background-color: rgba(204, 36, 29, 0.5);
+                border-color: #cc241d;
+                color: #9d0006;
+            }
+            div.details table tbody td b.ABORTED,
+            div.details table tbody td b.NODE_FAILURE,
+            div.details table tbody td b.RETRY,
+            div.details table tbody td b.RETRY_LIMIT {
+                background-color: rgba(215, 153, 33, 0.5);
+                border-color: #d79921;
+                color: #b57614;
+            }
+            div.details table tbody td b.voting {
+                border-style: solid;
+            }
+            div.details table tbody td b.non-voting {
+                border-style: dotted;
+            }
+
             footer a,
             footer a:visited {
                 border-bottom: 1px dotted #000;

--- a/zjb/templates/base.html.j2
+++ b/zjb/templates/base.html.j2
@@ -285,23 +285,60 @@
                 let select = document.getElementById('group');
                 let search = document.getElementById('search');
 
-                for(const group in groups) {
-                    const option = document.createElement('option');
-                    const text = document.createTextNode(group);
-                    option.appendChild(text);
-                    select.appendChild(option);
+                if(select) {
+                    for(const group in groups) {
+                        const option = document.createElement('option');
+                        const text = document.createTextNode(group);
+                        option.appendChild(text);
+                        select.appendChild(option);
+                    }
+
+                    select.addEventListener('change', function(event) {
+                        selected = event.target.value;
+                        filterRows();
+                    });
                 }
 
-                select.addEventListener('change', function(event) {
-                    selected = event.target.value;
-                    filterRows();
-                });
+                if(search) {
+                    search.addEventListener('input', function(event) {
+                        searched = event.target.value.toLowerCase();
+                        filterRows();
+                        updateURL();
+                    });
 
-                search.addEventListener('input', function(event) {
-                    searched = event.target.value.toLowerCase();
-                    filterRows();
-                    updateURL();
-                });
+                    let failed = document.getElementById('failed');
+                    failed.addEventListener('click', function(event) {
+                        search.value = '(FAILURE|RETRY|ABORT)';
+                        searched = search.value.toLowerCase();
+                        filterRows();
+                        updateURL();
+                    });
+
+                    let tested = document.getElementById('tested');
+                    tested.addEventListener('click', function(event) {
+                        search.value = '(SUCCESS|FAILURE|RETRY|ABORT)';
+                        searched = search.value.toLowerCase();
+                        filterRows();
+                        updateURL();
+                    });
+
+                    let untested = document.getElementById('untested');
+                    untested.addEventListener('click', function(event) {
+                        search.value = '^((?!(SUCCESS|FAILURE|RETRY|ABORT)).)*$';
+                        searched = search.value.toLowerCase();
+                        filterRows();
+                        updateURL();
+                    });
+
+                    {% if query -%}
+                    search.value = {{ query | tojson }};
+                    if(search.value) {
+                        searched = search.value.toLowerCase();
+                        filterRows();
+                        updateURL();
+                    }
+                    {%- endif %}
+                }
 
                 let tables = document.querySelectorAll('table');
                 for(const table of tables) {
@@ -315,37 +352,6 @@
                             element.hidden = ! element.hidden;
                         }
                     });
-                }
-
-                let failed = document.getElementById('failed');
-                failed.addEventListener('click', function(event) {
-                    search.value = '(FAILURE|RETRY|ABORT)';
-                    searched = search.value.toLowerCase();
-                    filterRows();
-                    updateURL();
-                });
-
-                let tested = document.getElementById('tested');
-                tested.addEventListener('click', function(event) {
-                    search.value = '(SUCCESS|FAILURE|RETRY|ABORT)';
-                    searched = search.value.toLowerCase();
-                    filterRows();
-                    updateURL();
-                });
-
-                let untested = document.getElementById('untested');
-                untested.addEventListener('click', function(event) {
-                    search.value = '^((?!(SUCCESS|FAILURE|RETRY|ABORT)).)*$';
-                    searched = search.value.toLowerCase();
-                    filterRows();
-                    updateURL();
-                });
-
-                search.value = {{ query | tojson }};
-                if(search.value) {
-                    searched = search.value.toLowerCase();
-                    filterRows();
-                    updateURL();
                 }
             });
         </script>

--- a/zjb/templates/base.html.j2
+++ b/zjb/templates/base.html.j2
@@ -363,24 +363,8 @@
                 <h2>– neatly presented statuses</h2>
             </a>
         </header>
-        <nav>
-            <div>
-                <label for="group">Group:</label>
-                <select name="group" id="group">
-                    <option>ANY</option>
-                </select>
-            </div>
-            <div>
-                <label for="search">Search:</label>
-                <input type="search" name="search" id="search" autocomplete="off" />
-            </div>
-            <div>
-                <label>Quick:</label>
-                <input type="button" id="failed" value="Failed" />
-                <input type="button" id="tested" value="Tested" />
-                <input type="button" id="untested" value="Untested" />
-            </div>
-        </nav>
+        {% block navigation %}
+        {% endblock %}
         <main class="index">
             {% block content %}
             {% endblock %}

--- a/zjb/templates/details.html.j2
+++ b/zjb/templates/details.html.j2
@@ -1,0 +1,38 @@
+{% extends "base.html.j2" %}
+{% block content %}
+    <div class="details" id="details-for-{{ result.id }}">
+        <form action="{{ url_prefix }}details?id={{ result.id }}" method="post">
+            <strong>Result details</strong>
+            <table>
+                <tr>
+                    <td>Project:</td>
+                    <td><b>{{ result.project }}</b></td>
+                    <td>Job name:</td>
+                    <td><b>{{ result.job }}</b></td>
+                </tr>
+                <tr>
+                    <td>Branch:</td>
+                    <td><b>{{ result.branch }}</b></td>
+                    <td>Pipeline:</td>
+                    <td><b>{{ result.pipeline }}</b></td>
+                </tr>
+                <tr>
+                    <td>Status:</td>
+                    <td><b class="status {{ result.status }} {% if result.voting %}voting{% else %}non-voting{% endif %}">{{ result.status }}</b></td>
+                    <td>Date:</td>
+                    <td>{% if result.date %}<b>{{ result.date }}</b>{% else %}(N/A){% endif %}</td>
+                </tr>
+                <tr>
+                    <td>UUID:</td>
+                    <td>{% if result.uuid %}<b>{{ result.uuid }}</b>{% else %}(N/A){% endif %}</td>
+                    <td>Updated:</td>
+                    <td><b>{{ result.updated }}</b></td>
+                </tr>
+                <tr>
+                    <td>Logs:</td>
+                    <td class="log" colspan="3">{% if result.URL %}<a href="{{ result.URL }}">{{ result.URL }}</a>{% else %}(N/A){% endif %}</td>
+                </tr>
+            </table>
+        </form>
+    </div>
+{% endblock %}

--- a/zjb/templates/index.html.j2
+++ b/zjb/templates/index.html.j2
@@ -4,7 +4,7 @@
                 <h1>Select view</h1>
                 <ul>
                     {%- for view in views | sort %}
-                    <li><a href="{{ url_prefix }}{{ view }}">{{ view }}</a></li>
+                    <li><a href="{{ url_prefix }}view/{{ view }}">{{ view }}</a></li>
                     {%- endfor -%}
                 </ul>
             </div>

--- a/zjb/templates/results.html.j2
+++ b/zjb/templates/results.html.j2
@@ -1,4 +1,24 @@
 {% extends "base.html.j2" %}
+{% block navigation %}
+        <nav>
+            <div>
+                <label for="group">Group:</label>
+                <select name="group" id="group">
+                    <option>ANY</option>
+                </select>
+            </div>
+            <div>
+                <label for="search">Search:</label>
+                <input type="search" name="search" id="search" autocomplete="off" />
+            </div>
+            <div>
+                <label>Quick:</label>
+                <input type="button" id="failed" value="Failed" />
+                <input type="button" id="tested" value="Tested" />
+                <input type="button" id="untested" value="Untested" />
+            </div>
+        </nav>
+{% endblock %}
 {% block content %}
             {%- for pipeline in results %}
             <table>

--- a/zjb/templates/results.html.j2
+++ b/zjb/templates/results.html.j2
@@ -46,7 +46,7 @@
                         {%- for result in project_results %}
                         <td>
                             {%- if result -%}
-                            <a class="status {{ result.status }} {% if result.voting %}voting{% else %}non-voting{% endif %}" href="{{ result.URL }}">{{ result.status }}</a>
+                            <a class="status {{ result.status }} {% if result.voting %}voting{% else %}non-voting{% endif %}" href="{{ url_prefix }}details?id={{ result.id }}">{{ result.status }}</a>
                             {%- endif -%}
                         </td>
                         {%- endfor -%}

--- a/zjb/templates/results.html.j2
+++ b/zjb/templates/results.html.j2
@@ -40,11 +40,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {%- for project_name, project_jobs in results[pipeline].items() %}
+                    {%- for project_name, project_results in results[pipeline].items() %}
                     <tr>
                         <td>{{ project_name }}</td>
-                        {%- for job in project_jobs %}
-                        <td><a class="status {{ job.status }} {% if job.voting %}voting{% else %}non-voting{% endif %}"{% if job.URL %} href="{{ job.URL }}"{% endif %}>{{ job.status }}</a></td>
+                        {%- for result in project_results %}
+                        <td>
+                            {%- if result -%}
+                            <a class="status {{ result.status }} {% if result.voting %}voting{% else %}non-voting{% endif %}" href="{{ result.URL }}">{{ result.status }}</a>
+                            {%- endif -%}
+                        </td>
                         {%- endfor -%}
                     </tr>
                     {%- endfor -%}

--- a/zjb/zuul.py
+++ b/zjb/zuul.py
@@ -62,7 +62,6 @@ def get_projects(filter: Optional[list] = None) -> list:
     return projects
 
 
-# TODO: caching here will help with the same queries from multiple views
 def get_last_build(project=None, branch=None, pipeline=None, job=None) -> dict:
     params = {'limit': 1}
 


### PR DESCRIPTION
This includes the following changes:

- Move views to dedicated endpoint

    When the Zuul Jobs Board was a simple application,
    it was enough to select views under first-level paths.
    However now we host more dedicated endpoints, hence
    it is better to move views under dedicated path.

- Add subpage for viewing single build details

    This commit introduces a dedicated subpage that
    allows to browse all details of a single result.

- Save build date in the database

- Return entity dicts directly

    Instead of creating dedicated dictionaries, we can return
    the full dictionaries of database entities directly. This
    allows to reach all needed fields without any extra steps
    and concentrates data-related manipulations in one place.

- Remove obsolete TODO note

- Move db query from server to db module

- Move search bar only to results list

    So far the navigation was present on all subpages,
    while it was only useful on the results page. This
    commit makes it present only where it is desired.

- Minor JavaScript tidies

    This commit includes query code only if needed
    and prevents errors if required navigation components
    are not present in HTML DOM elements.